### PR TITLE
28zepzv delete family member

### DIFF
--- a/apps/families/tests/views/test_family_members.py
+++ b/apps/families/tests/views/test_family_members.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 from rest_framework import status
 
+from apps.families.models import FamilyInvitation, Membership
 from apps.families.tests.factories import (
     FamilyFactory,
     FamilyInvitationFactory,
@@ -62,3 +63,65 @@ class ListFamilyMembersViewSetTests(CustomTestCase):
             self.members + [self.user_membership],
             response.json(),
         )
+
+
+class RemoveFamilyMembersViewSetTests(CustomTestCase):
+    def _build_url(self, family_id, user_id):
+        return reverse(
+            "families:family-members-delete",
+            kwargs={"family_id": family_id, "user_id": user_id},
+        )
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.family = FamilyFactory()
+        cls.user_membership = MembershipFactory(user=cls.user, family=cls.family)
+        # User has pending invitation
+        FamilyInvitationFactory(email=cls.user.email)
+
+        cls.members = MembershipFactory.create_batch(size=2, family=cls.family)
+
+    def setUp(self):
+        super().setUp()
+        self.backend.login(self.user)
+
+    def test_access_permission(self):
+        url = self._build_url(self.family.id, self.user.id)
+
+        self.backend.logout()
+        self.backend.delete(url, status=status.HTTP_401_UNAUTHORIZED)
+
+        # Member of no family
+        non_member_user = UserFactory()
+        self.backend.login(non_member_user)
+        self.backend.delete(url, status=status.HTTP_403_FORBIDDEN)
+        self.backend.logout()
+
+        # Member of other family
+        MembershipFactory(user=non_member_user)
+        self.backend.login(non_member_user)
+        self.backend.delete(url, status=status.HTTP_403_FORBIDDEN)
+        self.backend.logout()
+
+        self.backend.login(self.user)
+        self.backend.delete(url, status=status.HTTP_200_OK)
+
+    def test_remove_already_member_user(self):
+        user = self.members[0].user
+        url = self._build_url(self.family.id, user.id)
+        self.backend.delete(url, status=status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(
+            Membership.objects.filter(family=self.family, user=user).exists()
+        )
+
+    def test_remove_pending_member_user(self):
+        url = self._build_url(self.family.id, self.user.id)
+        self.backend.delete(url, status=status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(
+            Membership.objects.filter(family=self.family, user=self.user).exists()
+        )
+        invitation = FamilyInvitation.objects.get(email=self.user.email)
+        self.assertEqual(invitation.status, "RE")

--- a/apps/families/urls.py
+++ b/apps/families/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
         name="family-members",
     ),
     path(
+        "<family_id>/delete-member/<user_id>",
+        FamilyMembersViewSet.as_view({"delete": "destroy"}),
+        name="family-members-delete",
+    ),
+    path(
         "<family_id>/create-invitation",
         FamilyInvitationViewSet.as_view({"post": "create"}),
         name="family-create-invitation",

--- a/apps/families/views/family_members_views.py
+++ b/apps/families/views/family_members_views.py
@@ -1,10 +1,15 @@
+from django.db import transaction
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from apps.families.models import Membership
+from apps.families.models import FamilyInvitation, InvitationStatus, Membership
 from apps.families.permissions import UserIsFamilyMemberPermission
 from apps.families.serializers import FamilyMemberSerializer
+from apps.users.models import User
 
 
 @extend_schema_view(
@@ -19,8 +24,27 @@ class FamilyMembersViewSet(ModelViewSet):
     serializer_class = FamilyMemberSerializer
     permission_classes = [IsAuthenticated, UserIsFamilyMemberPermission]
 
+    def get_user(self):
+        return get_object_or_404(User, id=self.kwargs.get("user_id"))
+
     def get_queryset(self):
         qs = super().get_queryset()
         qs = qs.filter(family__id=self.kwargs["family_id"])
 
         return qs
+
+    def destroy(self, request, *args, **kwargs):
+        user = self.get_user()
+        qs = self.get_queryset()
+
+        with transaction.atomic():
+            instance = qs.filter(user=user)
+            self.perform_destroy(instance)
+
+            # Revoking invitation if pending
+            invitation = FamilyInvitation.objects.filter(email=user.email).first()
+            if invitation and invitation.status == InvitationStatus.PENDING:
+                invitation.status = InvitationStatus.REVOKED
+                invitation.save()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/families/views/family_views.py
+++ b/apps/families/views/family_views.py
@@ -15,7 +15,9 @@ class UserFamiliesViewSet(CustomModelViewSet):
 
     def get_permissions(self):
         if self.action in ["destroy", "partial_update"]:
-            self.permission_classes = self.permission_classes + [UserIsFamilyMemberPermission]
+            self.permission_classes = self.permission_classes + [
+                UserIsFamilyMemberPermission
+            ]
 
         return super().get_permissions()
 


### PR DESCRIPTION
Added endpoint to delete a family member.

If the user had a related family invitation with the same email and with pending state, that invitation had to be revoked while deleting the membership.